### PR TITLE
Fix a typo and add Gentoo installation instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ On Debian-based systems, you can install "pdflatex" with:
 
     sudo apt-get install texlive-latex-extra
 
+On Gentoo-based systems, "pdflatex" and required extra pacakges can be installed with:
+
+    emerge texlive-latexrecommended xcolor
+
 ## Issues
 
     "File `todonotes.sty' not found."


### PR DESCRIPTION
Hi,
I noticed a minor typo (and some extra whitespace) in the readme. Also I spent a few minutes figuring out what packages were required to build a pdf on my distro (Gentoo), and added them to the readme to hopefully save others some time.
